### PR TITLE
Switch waiter redirects to route endpoints

### DIFF
--- a/app/Controllers/WaiterController.php
+++ b/app/Controllers/WaiterController.php
@@ -16,7 +16,7 @@ class WaiterController {
     // 🔹 Página de login
     public function loginPage() {
         if (isset($_SESSION['branch_id'])) {
-            header("Location: /waiter/orders.php");
+            header("Location: /waiter/orders");
             exit;
         }
         include __DIR__ . "/../../public/waiter/login.php";
@@ -29,7 +29,7 @@ class WaiterController {
 
         if (!$branchId || !$password) {
             $_SESSION['error'] = "Debes seleccionar sucursal y clave";
-            header("Location: /waiter/login.php");
+            header("Location: /waiter/login");
             exit;
         }
 
@@ -37,28 +37,29 @@ class WaiterController {
 
         if (!$branch) {
             $_SESSION['error'] = "Sucursal no encontrada";
-            header("Location: /waiter/login.php");
+            header("Location: /waiter/login");
             exit;
         }
 
         if (!isset($branch['access_key']) || $branch['access_key'] !== $password) {
             $_SESSION['error'] = "Clave incorrecta";
-            header("Location: /waiter/login.php");
+            header("Location: /waiter/login");
             exit;
         }
 
         // Guardar sesión
         $_SESSION['branch_id']   = $branch['id'];
         $_SESSION['branch_name'] = $branch['name'];
+        session_write_close();
 
-        header("Location: /waiter/orders.php");
+        header("Location: /waiter/orders");
         exit;
     }
 
     // 🔹 Página de pedidos
     public function ordersPage() {
         if (!isset($_SESSION['branch_id'])) {
-            header("Location: /waiter/login.php");
+            header("Location: /waiter/login");
             exit;
         }
         include __DIR__ . "/../../public/waiter/orders.php";
@@ -68,7 +69,7 @@ class WaiterController {
     public function logout() {
         session_start();
         session_destroy();
-        header("Location: /waiter/login.php");
+        header("Location: /waiter/login");
         exit;
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -111,6 +111,11 @@ case '/waiter/login':
     if ($method === 'GET') $controller->loginPage();
     elseif ($method === 'POST') $controller->login();
     break;
+
+case '/waiter/orders':
+    $controller = new WaiterController();
+    if ($method === 'GET') $controller->ordersPage();
+    break;
     
 // 🔹 Orders para meseros
 case '/orders/waiter':


### PR DESCRIPTION
## Summary
- Replace hardcoded waiter redirects to `.php` files with cleaner route paths
- Close session writes on waiter login before redirecting to orders page
- Register `/waiter/orders` route to serve the waiter orders page

## Testing
- `php -l app/Controllers/WaiterController.php`
- `php -l public/index.php`
- `php -l public/waiter/orders.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb33d8fcfc832f8a3cb0a44b8eeaa8