### PR TITLE
Allow alphanumeric table identifiers

### DIFF
--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -28,7 +28,7 @@ class Table {
                   VALUES (:branch_id, :table_number, :qr_code)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":branch_id", $branchId, PDO::PARAM_INT);
-        $stmt->bindParam(":table_number", $tableNumber);
+        $stmt->bindParam(":table_number", $tableNumber, PDO::PARAM_STR);
         $stmt->bindParam(":qr_code", $qrCode);
         return $stmt->execute();
     }
@@ -41,7 +41,7 @@ class Table {
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":id", $id, PDO::PARAM_INT);
         $stmt->bindParam(":branch_id", $branchId, PDO::PARAM_INT);
-        $stmt->bindParam(":table_number", $tableNumber);
+        $stmt->bindParam(":table_number", $tableNumber, PDO::PARAM_STR);
         $stmt->bindParam(":qr_code", $qrCode);
         return $stmt->execute();
     }

--- a/public/js/branches.js
+++ b/public/js/branches.js
@@ -148,7 +148,7 @@ function addTableRow() {
   const tbody = $('#tablesTable tbody');
   const row = `
     <tr>
-      <td><input type="number" class="form-control" placeholder="#" /></td>
+      <td><input type="text" class="form-control" placeholder="Identificador" /></td>
       <td></td>
       <td>
         <button class="btn btn-sm btn-success me-1" onclick="saveTable(this.closest('tr'))">💾</button>
@@ -162,7 +162,7 @@ function addTableRow() {
 function editTable(row, id) {
   const number = $(row).find('td:first').text();
   $(row).html(`
-    <td><input type="number" class="form-control" value="${number}" /></td>
+    <td><input type="text" class="form-control" value="${number}" /></td>
     <td></td>
     <td>
       <button class="btn btn-sm btn-success me-1" onclick="saveTable(this.closest('tr'), ${id})">💾</button>
@@ -172,15 +172,15 @@ function editTable(row, id) {
 }
 
 function saveTable(row, id) {
-  const number = $(row).find('input').val();
+  const tableNumber = $(row).find('input').val().trim();
   const branchId = $('#tablesBranchId').val();
 
-  if (!number) {
+  if (!tableNumber) {
     Swal.fire('Error', 'Número de mesa requerido', 'warning');
     return;
   }
 
-  const payload = { branch_id: branchId, table_number: number };
+  const payload = { branch_id: branchId, table_number: tableNumber };
   if (id) payload.id = id;
 
   fetch('/tables', {


### PR DESCRIPTION
## Summary
- Let branch table inputs accept alphanumeric values
- Send table numbers as raw strings to the backend
- Bind table_number as string in Table model

## Testing
- `node --check public/js/branches.js`
- `php -l app/Models/Table.php`
- `composer test` *(fails: Command "test" is not defined)*
- `npm test --silent` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bb338051d0832fa0d6a4e78637a1cd