### PR TITLE
Harden PHP session handling

### DIFF
--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -10,7 +10,16 @@ class AuthController {
     public function __construct() {
         $db = new Database();
         $this->conn = $db->getConnection();
-        session_start();
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_set_cookie_params([
+                'lifetime' => 0,
+                'path' => '/',
+                'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+                'httponly' => true,
+                'samesite' => 'Strict'
+            ]);
+            session_start();
+        }
     }
 
     // POST /auth/login
@@ -26,6 +35,7 @@ class AuthController {
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($user && password_verify($password, $user['password'])) {
+            session_regenerate_id(true);
             $_SESSION['user'] = [
                 "id"=>$user['id'],
                 "username"=>$user['username'],

--- a/app/Controllers/WaiterController.php
+++ b/app/Controllers/WaiterController.php
@@ -8,7 +8,14 @@ class WaiterController {
 
     public function __construct() {
         $this->branchModel = new Branch();
-        if (session_status() === PHP_SESSION_NONE) {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_set_cookie_params([
+                'lifetime' => 0,
+                'path' => '/',
+                'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+                'httponly' => true,
+                'samesite' => 'Strict'
+            ]);
             session_start();
         }
     }
@@ -48,6 +55,7 @@ class WaiterController {
         }
 
         // Guardar sesión
+        session_regenerate_id(true);
         $_SESSION['branch_id']   = $branch['id'];
         $_SESSION['branch_name'] = $branch['name'];
 
@@ -66,7 +74,16 @@ class WaiterController {
 
     // 🔹 Logout
     public function logout() {
-        session_start();
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_set_cookie_params([
+                'lifetime' => 0,
+                'path' => '/',
+                'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+                'httponly' => true,
+                'samesite' => 'Strict'
+            ]);
+            session_start();
+        }
         session_destroy();
         header("Location: /waiter/login.php");
         exit;

--- a/public/auth.php
+++ b/public/auth.php
@@ -1,5 +1,14 @@
 <?php
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+        'httponly' => true,
+        'samesite' => 'Strict'
+    ]);
+    session_start();
+}
 require __DIR__ . "/../vendor/autoload.php";
 
 use App\Config\Database;
@@ -25,6 +34,7 @@ if ($method === "POST") {
     $user = $stmt->fetch(PDO::FETCH_ASSOC);
 
     if ($user && password_verify($password, $user['password'])) {
+        session_regenerate_id(true);
         $_SESSION['user'] = [
             "id" => $user['id'],
             "username" => $user['username'],

--- a/public/auth_middleware.php
+++ b/public/auth_middleware.php
@@ -1,5 +1,12 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_set_cookie_params([
+    'lifetime' => 0,
+    'path' => '/',
+    'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+    'httponly' => true,
+    'samesite' => 'Strict'
+  ]);
   session_start();
 }
 

--- a/public/login.php
+++ b/public/login.php
@@ -1,5 +1,14 @@
 <?php
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+        'httponly' => true,
+        'samesite' => 'Strict'
+    ]);
+    session_start();
+}
 if (isset($_SESSION['user'])) {
   header("Location: /admin/dashboard.php");
   exit;

--- a/public/waiter/login.php
+++ b/public/waiter/login.php
@@ -1,5 +1,14 @@
 <?php
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+        'httponly' => true,
+        'samesite' => 'Strict'
+    ]);
+    session_start();
+}
 $error = $_SESSION['error'] ?? null;
 $oldBranch = $_SESSION['old_branch'] ?? "";
 unset($_SESSION['error'], $_SESSION['old_branch']);

--- a/public/waiter/orders.php
+++ b/public/waiter/orders.php
@@ -1,5 +1,14 @@
 <?php
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path' => '/',
+        'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+        'httponly' => true,
+        'samesite' => 'Strict'
+    ]);
+    session_start();
+}
 if (!isset($_SESSION['branch_id'])) {
     header("Location: /waiter/login");
     exit;


### PR DESCRIPTION
## Summary
- Guard against duplicate sessions by checking `session_status()` before `session_start()` and configuring secure cookie params
- Regenerate session IDs after successful logins to prevent fixation

## Testing
- `php -l public/auth.php`
- `php -l public/waiter/login.php`
- `php -l public/waiter/orders.php`
- `php -l public/login.php`
- `php -l public/auth_middleware.php`
- `php -l app/Controllers/AuthController.php`
- `php -l app/Controllers/WaiterController.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2d8f8b2c832fa36244126cef27e4