### PR TITLE
Ensure active session before waiter logout

### DIFF
--- a/app/Controllers/WaiterController.php
+++ b/app/Controllers/WaiterController.php
@@ -66,8 +66,9 @@ class WaiterController {
 
     // 🔹 Logout
     public function logout() {
-        session_start();
-        session_destroy();
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
         header("Location: /waiter/login.php");
         exit;
     }


### PR DESCRIPTION
## Summary
- Avoid restarting sessions in `WaiterController::logout` by checking for an active session before destroying it

## Testing
- `php -l app/Controllers/WaiterController.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e2fb640832fa619c6193ea49065