### PR TITLE
Sanitize order rendering with DOM nodes

### DIFF
--- a/manual-tests/orders-sanitization.md
+++ b/manual-tests/orders-sanitization.md
@@ -1,0 +1,17 @@
+# Pruebas manuales de saneamiento en Orders.js
+
+1. Simular respuesta del servidor con datos maliciosos desde la consola del navegador:
+   ```javascript
+   const orders = [{
+     table_number: "<img src=x onerror=alert('xss')>",
+     customer_name: "<script>alert('xss')</script>",
+     customer_phone: "\" onclick=alert('xss') \"",
+     created_at: "2024-01-01",
+     status: "pendiente",
+     id: 99
+   }];
+   window.fetch = () => Promise.resolve({ json: () => Promise.resolve(orders) });
+   loadOrders();
+   ```
+2. Verificar en la interfaz que los valores aparecen como texto literal y que **no** se ejecuta ningún `alert`.
+3. Repetir la prueba para cada campo y estado del pedido.

--- a/public/Orders.js
+++ b/public/Orders.js
@@ -1,7 +1,7 @@
 const branchId = 1; // 👉 puedes cambiar esto o leerlo desde la URL (?branch=1)
 
 function loadOrders() {
-  fetch(`/orders?branch_id=${branchId}`)
+  fetch('/orders?branch_id=' + encodeURIComponent(branchId))
     .then(r => r.json())
     .then(orders => {
       // Limpiar columnas
@@ -13,37 +13,69 @@ function loadOrders() {
       orders.forEach(o => {
         const card = document.createElement("div");
         card.className = "kanban-card";
-        card.innerHTML = `
-          <b>Mesa ${o.table_number}</b> <br>
-          Cliente: ${o.customer_name} <br>
-          <small>Tel: ${o.customer_phone}</small><br>
-          <small>Hora: ${o.created_at}</small><br>
-          <div class="mt-2">
-            ${renderButtons(o)}
-          </div>
-        `;
+
+        const table = document.createElement("b");
+        table.textContent = `Mesa ${o.table_number}`;
+        card.appendChild(table);
+        card.appendChild(document.createElement("br"));
+
+        const customer = document.createElement("div");
+        customer.textContent = `Cliente: ${o.customer_name}`;
+        card.appendChild(customer);
+
+        const phone = document.createElement("small");
+        phone.textContent = `Tel: ${o.customer_phone}`;
+        card.appendChild(phone);
+        card.appendChild(document.createElement("br"));
+
+        const time = document.createElement("small");
+        time.textContent = `Hora: ${o.created_at}`;
+        card.appendChild(time);
+        card.appendChild(document.createElement("br"));
+
+        const btnContainer = document.createElement("div");
+        btnContainer.className = "mt-2";
+        btnContainer.appendChild(renderButtons(o));
+        card.appendChild(btnContainer);
+
         document.getElementById(`col-${o.status}`).appendChild(card);
       });
     });
 }
 
 function renderButtons(order) {
+  let btn;
   switch(order.status) {
     case "pendiente":
-      return `<button class="btn btn-sm btn-primary w-100" onclick="updateStatus(${order.id}, 'preparando')">Iniciar</button>`;
+      btn = document.createElement("button");
+      btn.className = "btn btn-sm btn-primary w-100";
+      btn.textContent = "Iniciar";
+      btn.addEventListener("click", () => updateStatus(order.id, 'preparando'));
+      return btn;
     case "preparando":
-      return `<button class="btn btn-sm btn-warning w-100" onclick="updateStatus(${order.id}, 'listo')">Marcar Listo</button>`;
+      btn = document.createElement("button");
+      btn.className = "btn btn-sm btn-warning w-100";
+      btn.textContent = "Marcar Listo";
+      btn.addEventListener("click", () => updateStatus(order.id, 'listo'));
+      return btn;
     case "listo":
-      return `<button class="btn btn-sm btn-success w-100" onclick="updateStatus(${order.id}, 'entregado')">Entregar</button>`;
+      btn = document.createElement("button");
+      btn.className = "btn btn-sm btn-success w-100";
+      btn.textContent = "Entregar";
+      btn.addEventListener("click", () => updateStatus(order.id, 'entregado'));
+      return btn;
     case "entregado":
-      return `<span class="badge bg-success">✔️ Entregado</span>`;
+      const span = document.createElement("span");
+      span.className = "badge bg-success";
+      span.textContent = "✔️ Entregado";
+      return span;
     default:
-      return "";
+      return document.createDocumentFragment();
   }
 }
 
 function updateStatus(id, status) {
-  fetch(`/orders/status?id=${id}`, {
+  fetch('/orders/status?id=' + encodeURIComponent(id), {
     method: "PUT",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify({status})


### PR DESCRIPTION
## Summary
- render order cards using `document.createElement` and `textContent`
- encode query params and attach event handlers without inline HTML
- add manual instructions to test sanitization against malicious data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2e32b2d8832f8f84c1e3c17bf474