### PR TITLE
feat: stream orders to waiters via SSE

### DIFF
--- a/app/Controllers/OrderController.php
+++ b/app/Controllers/OrderController.php
@@ -104,4 +104,33 @@ class OrderController {
             echo json_encode(["error" => "No se pudo cancelar"]);
         }
     }
+
+    // ================== STREAMING ==================
+
+    // GET /orders/stream?branch_id=1&status=pending
+    public function stream() {
+        if (!isset($_GET['branch_id'])) {
+            http_response_code(400);
+            echo "branch_id required";
+            return;
+        }
+
+        $branchId = intval($_GET['branch_id']);
+        $status   = $_GET['status'] ?? null;
+
+        header('Content-Type: text/event-stream');
+        header('Cache-Control: no-cache');
+        header('Connection: keep-alive');
+
+        while (true) {
+            $orders = $this->model->getByBranch($branchId, $status);
+            echo 'data: ' . json_encode(['data' => $orders]) . "\n\n";
+            @ob_flush();
+            flush();
+            if (connection_aborted()) {
+                break;
+            }
+            sleep(3);
+        }
+    }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -57,6 +57,12 @@ switch ($uri) {
         }
         break;
 
+    case '/orders/stream':
+        if ($method === 'GET') {
+            (new OrderController())->stream();
+        }
+        break;
+
     // 🔹 Customers
     case '/customers':
         if ($method === 'POST') {

--- a/public/waiter/orders.php
+++ b/public/waiter/orders.php
@@ -53,7 +53,7 @@ $branchName = $_SESSION['branch_name'];
       <option value="entregado">Entregados</option>
       <option value="cancelado">Cancelados</option>
     </select>
-    <button class="btn btn-sm btn-secondary" onclick="loadOrders()">🔄</button>
+    <button class="btn btn-sm btn-secondary" onclick="connectStream()">🔄</button>
   </div>
 
   <!-- Pedidos -->
@@ -62,6 +62,7 @@ $branchName = $_SESSION['branch_name'];
 
 <script>
 const branchId = <?= $branchId ?>;
+let eventSource;
 
 function renderStatusBadge(status) {
   const colors = {
@@ -81,38 +82,43 @@ function renderStatusBadge(status) {
   return `<span class="badge bg-${colors[status]||'dark'}">${labels[status]||status}</span>`;
 }
 
-function loadOrders() {
-  const status = document.getElementById("filterStatus").value;
-  fetch(`/orders?branch_id=${branchId}&status=${status}`)
-    .then(r=>r.json())
-    .then(res=>{
-      const list = document.getElementById("ordersList");
-      list.innerHTML = "";
-      (res.data||res).forEach(o=>{
-        list.innerHTML += `
-          <div class="col-12">
-            <div class="card shadow-sm order-card status-${o.status}">
-              <div class="card-body">
-                <div class="d-flex justify-content-between">
-                  <h6>#${o.id} ${renderStatusBadge(o.status)}</h6>
-                  <small>${o.created_at}</small>
-                </div>
-                <p class="mb-1"><strong>Mesa:</strong> ${o.table_number || 'N/A'}</p>
-                <p class="mb-1"><strong>Cliente:</strong> ${o.customer_name || 'N/A'}</p>
-                <p class="mb-2"><strong>Total:</strong> RD$ ${parseFloat(o.total||0).toFixed(2)}</p>
-                <div class="d-flex gap-2">
-                  ${renderButtons(o)}
-                </div>
-              </div>
+function renderOrders(res) {
+  const list = document.getElementById("ordersList");
+  list.innerHTML = "";
+  (res.data||res).forEach(o=>{
+    list.innerHTML += `
+      <div class="col-12">
+        <div class="card shadow-sm order-card status-${o.status}">
+          <div class="card-body">
+            <div class="d-flex justify-content-between">
+              <h6>#${o.id} ${renderStatusBadge(o.status)}</h6>
+              <small>${o.created_at}</small>
+            </div>
+            <p class="mb-1"><strong>Mesa:</strong> ${o.table_number || 'N/A'}</p>
+            <p class="mb-1"><strong>Cliente:</strong> ${o.customer_name || 'N/A'}</p>
+            <p class="mb-2"><strong>Total:</strong> RD$ ${parseFloat(o.total||0).toFixed(2)}</p>
+            <div class="d-flex gap-2">
+              ${renderButtons(o)}
             </div>
           </div>
-        `;
-      });
-    })
-    .catch(err=>{
-      Swal.fire("Error", "No se pudieron cargar pedidos", "error");
+        </div>
+      </div>
+    `;
+  });
+}
+
+function connectStream() {
+  const status = document.getElementById("filterStatus").value;
+  if (eventSource) eventSource.close();
+  eventSource = new EventSource(`/orders/stream?branch_id=${branchId}&status=${status}`);
+  eventSource.onmessage = (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      renderOrders(data);
+    } catch(err) {
       console.error(err);
-    });
+    }
+  };
 }
 
 function renderButtons(order) {
@@ -137,16 +143,16 @@ function changeStatus(id, status) {
     method: "PUT",
     headers: { "Content-Type":"application/json" },
     body: JSON.stringify({ status })
-  }).then(()=> loadOrders());
+  }).then(()=> connectStream());
 }
 
 function cancelOrder(id) {
   fetch(`/orders/cancel?id=${id}`, { method:"PUT" })
-    .then(()=> loadOrders());
+    .then(()=> connectStream());
 }
 
-loadOrders();
-setInterval(loadOrders, 5000); // refresco cada 5s
+connectStream();
+document.getElementById("filterStatus").addEventListener("change", connectStream);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `/orders/stream` endpoint delivering Server-Sent Events for branch orders
- consume SSE stream in waiter orders page instead of polling
- wire new stream route into public router

## Testing
- `php -l app/Controllers/OrderController.php`
- `php -l public/index.php`
- `php -l public/waiter/orders.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e349bdc832fa819ce8638900ef4