### PR TITLE
Use environment variables for database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Environment configuration for the SelfOrder project
+# Rename this file to .env and adjust the values as needed
+
+DB_HOST=127.0.0.1
+DB_NAME=selforder
+DB_USER=root
+DB_PASS=your_password

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore environment configuration file
+.env

--- a/config/Database.php
+++ b/config/Database.php
@@ -5,11 +5,18 @@ use PDO;
 use PDOException;
 
 class Database {
-    private $host = "127.0.0.1";
-    private $db_name = "selforder";
-    private $username = "root";
-    private $password = "Anfeliz112322";
+    private $host;
+    private $db_name;
+    private $username;
+    private $password;
     public $conn;
+
+    public function __construct() {
+        $this->host = getenv('DB_HOST') ?: '127.0.0.1';
+        $this->db_name = getenv('DB_NAME') ?: 'selforder';
+        $this->username = getenv('DB_USER') ?: 'root';
+        $this->password = getenv('DB_PASS') ?: '';
+    }
 
     public function getConnection() {
         $this->conn = null;


### PR DESCRIPTION
## Summary
- load database connection settings from environment variables
- provide `.env.example` and ignore real `.env`

## Testing
- `php -l config/Database.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6e4eccdec832fae0918e3c9154dc0