### PR TITLE
Harden database error handling

### DIFF
--- a/app/Controllers/BranchController.php
+++ b/app/Controllers/BranchController.php
@@ -2,7 +2,7 @@
 namespace App\Controllers;
 
 use App\Models\Branch;
-use Exception;
+use Throwable;
 
 class BranchController {
     private $model;
@@ -17,7 +17,7 @@ class BranchController {
         try {
             $branches = $this->model->getAll();
             echo json_encode(["data" => $branches]);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             http_response_code(500);
             echo json_encode(["error" => $e->getMessage()]);
         }
@@ -36,7 +36,7 @@ class BranchController {
         try {
             $success = $this->model->create($data['name'], $data['address'], $data['phone'], $data['access_key']);
             echo json_encode(["success"=>$success, "message"=>"Sucursal creada correctamente"]);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             http_response_code(500);
             echo json_encode(["success"=>false, "error"=>$e->getMessage()]);
         }
@@ -55,7 +55,7 @@ class BranchController {
         try {
             $success = $this->model->update($data['id'], $data['name'], $data['address'], $data['phone'], $data['access_key']);
             echo json_encode(["success"=>$success, "message"=>"Sucursal actualizada correctamente"]);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             http_response_code(500);
             echo json_encode(["success"=>false, "error"=>$e->getMessage()]);
         }
@@ -74,7 +74,7 @@ class BranchController {
         try {
             $success = $this->model->delete($id);
             echo json_encode(["success"=>$success, "message"=>"Sucursal eliminada correctamente"]);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             http_response_code(500);
             echo json_encode(["success"=>false, "error"=>$e->getMessage()]);
         }

--- a/app/Models/Branch.php
+++ b/app/Models/Branch.php
@@ -13,10 +13,17 @@ class Branch {
         $this->conn = $database->getConnection();
     }
 
+    private function ensureConnection() {
+        if ($this->conn === null) {
+            throw new \Exception('Conexión a la base de datos no establecida');
+        }
+    }
+
     // Obtener todas las sucursales
     public function getAll() {
-        $query = "SELECT id, name, address, phone, access_key 
-                  FROM {$this->table} 
+        $this->ensureConnection();
+        $query = "SELECT id, name, address, phone, access_key
+                  FROM {$this->table}
                   ORDER BY name ASC";
         $stmt = $this->conn->prepare($query);
         $stmt->execute();
@@ -25,7 +32,8 @@ class Branch {
 
     // Crear sucursal
     public function create($name, $address, $phone, $accessKey) {
-        $query = "INSERT INTO {$this->table} (name, address, phone, access_key) 
+        $this->ensureConnection();
+        $query = "INSERT INTO {$this->table} (name, address, phone, access_key)
                   VALUES (:name, :address, :phone, :access_key)";
         $stmt = $this->conn->prepare($query);
         return $stmt->execute([
@@ -38,8 +46,9 @@ class Branch {
 
     // Actualizar sucursal
     public function update($id, $name, $address, $phone, $accessKey) {
-        $query = "UPDATE {$this->table} 
-                  SET name = :name, address = :address, phone = :phone, access_key = :access_key 
+        $this->ensureConnection();
+        $query = "UPDATE {$this->table}
+                  SET name = :name, address = :address, phone = :phone, access_key = :access_key
                   WHERE id = :id";
         $stmt = $this->conn->prepare($query);
         return $stmt->execute([
@@ -53,17 +62,19 @@ class Branch {
 
     // Eliminar sucursal
     public function delete($id) {
+        $this->ensureConnection();
         $query = "DELETE FROM {$this->table} WHERE id = :id";
         $stmt = $this->conn->prepare($query);
         return $stmt->execute([":id" => $id]);
     }
 
     public function getById($id) {
-    $query = "SELECT * FROM " . $this->table . " WHERE id = :id";
-    $stmt = $this->conn->prepare($query);
-    $stmt->bindParam(":id", $id, PDO::PARAM_INT);
-    $stmt->execute();
-    return $stmt->fetch(PDO::FETCH_ASSOC);
-}
+        $this->ensureConnection();
+        $query = "SELECT * FROM " . $this->table . " WHERE id = :id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(":id", $id, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
 
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -12,14 +12,22 @@ class Category {
         $this->conn = $db->getConnection();
     }
 
+    private function ensureConnection() {
+        if ($this->conn === null) {
+            throw new \Exception('Conexión a la base de datos no establecida');
+        }
+    }
+
     // 🔹 Listar categorías
     public function getAll() {
+        $this->ensureConnection();
         $stmt = $this->conn->query("SELECT id, name FROM categories ORDER BY name ASC");
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     // 🔹 Crear categoría
     public function create($name) {
+        $this->ensureConnection();
         $stmt = $this->conn->prepare("INSERT INTO categories (name) VALUES (:name)");
         $stmt->execute([":name" => $name]);
         return $this->conn->lastInsertId();
@@ -27,6 +35,7 @@ class Category {
 
     // 🔹 Actualizar categoría
     public function update($id, $name) {
+        $this->ensureConnection();
         $stmt = $this->conn->prepare("UPDATE categories SET name = :name WHERE id = :id");
         return $stmt->execute([
             ":id"   => $id,
@@ -36,6 +45,7 @@ class Category {
 
     // 🔹 Eliminar categoría
     public function delete($id) {
+        $this->ensureConnection();
         $stmt = $this->conn->prepare("DELETE FROM categories WHERE id = :id");
         return $stmt->execute([":id" => $id]);
     }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -13,7 +13,14 @@ class Customer {
         $this->conn = $database->getConnection();
     }
 
+    private function ensureConnection() {
+        if ($this->conn === null) {
+            throw new \Exception('Conexión a la base de datos no establecida');
+        }
+    }
+
     public function create($name, $phone, $tableId) {
+        $this->ensureConnection();
         $q = "INSERT INTO " . $this->table . " (name, phone, table_id) VALUES (:name, :phone, :table_id)";
         $stmt = $this->conn->prepare($q);
         $stmt->bindParam(":name", $name);

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -13,7 +13,14 @@ class Setting {
         $this->conn = $db->getConnection();
     }
 
+    private function ensureConnection() {
+        if ($this->conn === null) {
+            throw new \Exception('Conexión a la base de datos no establecida');
+        }
+    }
+
     public function get() {
+        $this->ensureConnection();
         $q = "SELECT * FROM " . $this->table . " ORDER BY id DESC LIMIT 1";
         $stmt = $this->conn->prepare($q);
         $stmt->execute();

--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -13,8 +13,15 @@ class Table {
         $this->conn = $database->getConnection();
     }
 
+    private function ensureConnection() {
+        if ($this->conn === null) {
+            throw new \Exception('Conexión a la base de datos no establecida');
+        }
+    }
+
     // 🔹 Listar mesas de una sucursal
     public function getByBranch($branchId) {
+        $this->ensureConnection();
         $query = "SELECT * FROM " . $this->table . " WHERE branch_id = :branch_id";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":branch_id", $branchId, PDO::PARAM_INT);
@@ -24,7 +31,8 @@ class Table {
 
     // 🔹 Crear mesa
     public function create($branchId, $tableNumber, $qrCode = null) {
-        $query = "INSERT INTO " . $this->table . " (branch_id, table_number, qr_code) 
+        $this->ensureConnection();
+        $query = "INSERT INTO " . $this->table . " (branch_id, table_number, qr_code)
                   VALUES (:branch_id, :table_number, :qr_code)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":branch_id", $branchId, PDO::PARAM_INT);
@@ -35,8 +43,9 @@ class Table {
 
     // 🔹 Actualizar mesa
     public function update($id, $branchId, $tableNumber, $qrCode = null) {
-        $query = "UPDATE " . $this->table . " 
-                  SET table_number = :table_number, qr_code = :qr_code 
+        $this->ensureConnection();
+        $query = "UPDATE " . $this->table . "
+                  SET table_number = :table_number, qr_code = :qr_code
                   WHERE id = :id AND branch_id = :branch_id";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":id", $id, PDO::PARAM_INT);
@@ -48,6 +57,7 @@ class Table {
 
     // 🔹 Eliminar mesa
     public function delete($id) {
+        $this->ensureConnection();
         $query = "DELETE FROM " . $this->table . " WHERE id = :id";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":id", $id, PDO::PARAM_INT);
@@ -56,6 +66,7 @@ class Table {
 
     // 🔹 Obtener mesa por ID
     public function getById($id) {
+        $this->ensureConnection();
         $query = "SELECT * FROM " . $this->table . " WHERE id = :id";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(":id", $id, PDO::PARAM_INT);
@@ -65,6 +76,7 @@ class Table {
 
     // 🔹 Solo actualizar la ruta del QR
     public function updateQR($id, $path) {
+        $this->ensureConnection();
         $query = "UPDATE " . $this->table . " SET qr_code = :qr WHERE id = :id";
         $stmt = $this->conn->prepare($query);
         return $stmt->execute([":qr" => $path, ":id" => $id]);

--- a/config/Database.php
+++ b/config/Database.php
@@ -21,7 +21,7 @@ class Database {
             );
             $this->conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch(PDOException $e) {
-            echo "❌ Error de conexión: " . $e->getMessage();
+            throw new \Exception("❌ Error de conexión: " . $e->getMessage());
         }
         return $this->conn;
     }


### PR DESCRIPTION
## Summary
- Throw exceptions instead of echoing on database connection failure
- Validate model connections before preparing queries
- Catch `Throwable` in `BranchController` to handle fatal errors

## Testing
- `php -l config/Database.php app/Models/Branch.php app/Models/Category.php app/Models/Customer.php app/Models/Order.php app/Models/Product.php app/Models/Setting.php app/Models/Table.php app/Controllers/BranchController.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c6e4e986fc832fb3121959bb8534a3